### PR TITLE
Cannot modify the contents of Dictionary<string,string> while enumerating

### DIFF
--- a/common/Main.cs
+++ b/common/Main.cs
@@ -102,12 +102,13 @@ namespace RelaySamples
             }
 
             // get overrides from the environment
-            foreach (var prop in properties)
+            var keys = new List<string>(properties.Keys);
+            foreach (var key in keys)
             {
-                var env = Environment.GetEnvironmentVariable(prop.Key);
+                var env = Environment.GetEnvironmentVariable(key);
                 if (env != null)
                 {
-                    properties[prop.Key] = env;
+                    properties[key] = env;
                 }
             }
 


### PR DESCRIPTION
Cannot modify the contents of Dictionary<string,string> while enumerating the collection.  Can't even do so while enumerating Dictionary<K,V>.Keys.  Clone the keys first.